### PR TITLE
attempt to create log dir before logfile

### DIFF
--- a/LogKitten.java
+++ b/LogKitten.java
@@ -25,6 +25,16 @@ public class LogKitten {
 	private static boolean PRINT_MUTE = false;
 	
 	static {
+		File logPathDirectory = new File(LOG_PATH);
+		try {
+			if (!logPathDirectory.isDirectory()) { // ensure that the directory /home/lvuser/logs/ exists
+				logPathDirectory.mkdirs(); // otherwise create all the directories of the path
+			}
+		}
+		catch (SecurityException se) {
+			System.out.println("Could not create log directory");
+			se.printStackTrace();
+		}
 		String filePath = LOG_PATH + timestamp() + ".log"; // Set this sessions log to /home/lvuser/logs/[current time].log
 		File file = new File(filePath);
 		try {


### PR DESCRIPTION
PR will attempt to create the parent directory of the logfile before creating/writing to the file itself.

Note the use `File.mkdirs()` creates _all_ of the parent directories – very similar to the functionality of `$ mkdir -p`.

**HAS BEEN TESTED ON ROBORIO.**
